### PR TITLE
Let Title own its TextLayout instead of a static map

### DIFF
--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/Resources.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/Resources.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.graphics.TextLayout;
 import org.eclipse.swt.widgets.Display;
 
 public class Resources {
@@ -39,7 +38,6 @@ public class Resources {
 
 	private static final Map<RGB, Color> colorMap = new HashMap<>();
 	private static final Map<String, Font> fontMap = new HashMap<>();
-	private static final Map<String, TextLayout> textLayoutMap = new HashMap<>();
 
 	/*
 	 * Only static methods are used here.
@@ -135,17 +133,6 @@ public class Resources {
 		return font;
 	}
 
-	public static TextLayout getTextLayout(String uuid) {
-
-		TextLayout textLayout = textLayoutMap.get(uuid);
-		if(textLayout == null) {
-			textLayout = new TextLayout(getDisplay());
-			textLayoutMap.put(uuid, textLayout);
-		}
-
-		return textLayout;
-	}
-
 	@Override
 	protected void finalize() throws Throwable {
 
@@ -155,14 +142,6 @@ public class Resources {
 		for(Font font : fontMap.values()) {
 			if(font != null && !font.isDisposed()) {
 				font.dispose();
-			}
-		}
-		/*
-		 * Text Layouts
-		 */
-		for(TextLayout textLayout : textLayoutMap.values()) {
-			if(textLayout != null && !textLayout.isDisposed()) {
-				textLayout.dispose();
 			}
 		}
 	}

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Title.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Title.java
@@ -14,8 +14,6 @@
  *******************************************************************************/
 package org.eclipse.swtchart.internal;
 
-import java.util.UUID;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.events.PaintEvent;
@@ -71,7 +69,7 @@ public class Title implements ITitle, PaintListener {
 	/*
 	 * Used internally to track the text layout.
 	 */
-	private String textLayoutUUID = null;
+	private TextLayout textLayout = null;
 
 	public Title(Chart parent) {
 
@@ -93,7 +91,6 @@ public class Title implements ITitle, PaintListener {
 		 */
 		this.text = (text == null) ? getDefaultText() : text;
 		if(useTextLayout()) {
-			TextLayout textLayout = Resources.getTextLayout(textLayoutUUID);
 			textLayout.setText(text);
 		}
 		chart.updateLayout();
@@ -181,7 +178,6 @@ public class Title implements ITitle, PaintListener {
 	public void setStyleRanges(StyleRange[] ranges) {
 
 		initializeTextLayout();
-		TextLayout textLayout = Resources.getTextLayout(textLayoutUUID);
 		textLayout.setText(text);
 
 		styleRanges = ranges;
@@ -267,7 +263,6 @@ public class Title implements ITitle, PaintListener {
 		int width;
 		if(isVisible() && !text.trim().equals("")) { //$NON-NLS-1$
 			if(useTextLayout()) {
-				TextLayout textLayout = Resources.getTextLayout(textLayoutUUID);
 				Rectangle rectangle = textLayout.getBounds();
 				width = rectangle.width;
 				height = rectangle.height;
@@ -320,6 +315,10 @@ public class Title implements ITitle, PaintListener {
 
 		if(!chart.isDisposed()) {
 			chart.removePaintListener(this);
+		}
+		if(textLayout != null) {
+			textLayout.dispose();
+			textLayout = null;
 		}
 	}
 
@@ -387,7 +386,6 @@ public class Title implements ITitle, PaintListener {
 		int x = getBounds().x;
 		int y = getBounds().y;
 		if(useTextLayout()) {
-			TextLayout textLayout = Resources.getTextLayout(textLayoutUUID);
 			textLayout.draw(gc, x, y);
 		} else {
 			gc.drawText(text, x, y, true);
@@ -419,7 +417,6 @@ public class Title implements ITitle, PaintListener {
 			tmpGc.setBackground(chart.getBackground());
 			tmpGc.fillRectangle(image.getBounds());
 			if(useTextLayout()) {
-				TextLayout textLayout = Resources.getTextLayout(textLayoutUUID);
 				textLayout.draw(tmpGc, 0, 0);
 			} else {
 				tmpGc.setForeground(getForeground());
@@ -451,7 +448,7 @@ public class Title implements ITitle, PaintListener {
 	private boolean useTextLayout() {
 
 		boolean useTextLayout = (styleRanges != null);
-		if(useTextLayout && textLayoutUUID == null) {
+		if(useTextLayout && textLayout == null) {
 			initializeTextLayout();
 		}
 
@@ -460,8 +457,8 @@ public class Title implements ITitle, PaintListener {
 
 	private void initializeTextLayout() {
 
-		if(textLayoutUUID == null) {
-			textLayoutUUID = UUID.randomUUID().toString();
+		if(textLayout == null) {
+			textLayout = new TextLayout(Display.getDefault());
 		}
 	}
 }


### PR DESCRIPTION
Resources kept a static Map<String, TextLayout> keyed by a UUID that Title minted per instance, so the map never shared anything - it held one entry per Title and nothing ever removed them. Every chart that styled an axis title stranded a TextLayout for the lifetime of the JVM, roughly 2-3 KB of RSS each, which adds up in long sessions that open many charts or render reports through ImageFactory.

Title now creates its own TextLayout and disposes it in dispose(), which already runs when the chart goes away. The map, its accessor and the part of the finalizer that walked it are gone with it - that finalizer never ran anyway, since Resources is never instantiated.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])