### PR TITLE
Stop caching Colors in Resources

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/AbstractSeriesSettingsDialog.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/AbstractSeriesSettingsDialog.java
@@ -39,7 +39,6 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.swtchart.IEnumLabel;
 import org.eclipse.swtchart.extensions.barcharts.IBarSeriesSettings;
 import org.eclipse.swtchart.extensions.core.ISeriesSettings;
-import org.eclipse.swtchart.extensions.core.ResourceSupport;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
 import org.eclipse.swtchart.extensions.piecharts.ICircularSeriesSettings;
 import org.eclipse.swtchart.extensions.scattercharts.IScatterSeriesSettings;
@@ -200,7 +199,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				colorDialog.setText(title);
 				RGB rgbNew = colorDialog.open();
 				if(rgbNew != null) {
-					Color colorNew = ResourceSupport.getColor(rgbNew);
+					Color colorNew = new Color(rgbNew);
 					text.setBackground(colorNew);
 					consumer.accept(colorNew);
 				}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/SeriesEditingSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/SeriesEditingSupport.java
@@ -22,7 +22,6 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swtchart.ISeries;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.ISeriesSettings;
-import org.eclipse.swtchart.extensions.core.ResourceSupport;
 import org.eclipse.swtchart.extensions.core.SeriesLabelProvider;
 import org.eclipse.swtchart.extensions.core.SeriesListUI;
 import org.eclipse.swtchart.extensions.core.SeriesMapper;
@@ -148,7 +147,7 @@ public class SeriesEditingSupport extends EditingSupport {
 					break;
 				case SeriesLabelProvider.INDEX_COLOR:
 					if(object instanceof RGB rgbNew) {
-						Color color = ResourceSupport.getColor(rgbNew);
+						Color color = new Color(rgbNew);
 						SeriesLabelProvider.setColor(seriesSettings, color);
 					}
 					break;

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/SetColorAction.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/SetColorAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 Lablicate GmbH.
+ * Copyright (c) 2021, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.ColorDialog;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swtchart.ISeries;
-import org.eclipse.swtchart.Resources;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.ISeriesSettings;
 import org.eclipse.swtchart.extensions.core.SeriesLabelProvider;
@@ -66,7 +65,7 @@ public class SetColorAction extends AbstractMenuListener {
 					if(rgbNew != null) {
 						for(ISeries<?> series : selectedSeries) {
 							ISeriesSettings seriesSettings = baseChart.getSeriesSettings(series.getId());
-							Color color = Resources.getColor(rgbNew);
+							Color color = new Color(rgbNew);
 							SeriesLabelProvider.setColor(seriesSettings, color);
 							baseChart.applySeriesSettings(series, seriesSettings, true);
 						}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/AxisPage.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/AxisPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -303,7 +303,7 @@ public class AxisPage extends AbstractSelectorPage {
 			fontData.setHeight(titleFontSizes[i]);
 			Font font = Resources.getFont(fontData);
 			axes[i].getTitle().setFont(font);
-			Color color = Resources.getColor(titleColors[i]);
+			Color color = new Color(titleColors[i]);
 			axes[i].getTitle().setForeground(color);
 			axes[i].setRange(new Range(minRanges[i], maxRanges[i]));
 			axes[i].setPosition(positions[i]);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/AxisTickPage.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/AxisTickPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -178,7 +178,7 @@ public class AxisTickPage extends AbstractSelectorPage {
 			fontData.setHeight(fontSizes[i]);
 			Font font = Resources.getFont(fontData);
 			axes[i].getTick().setFont(font);
-			Color color = Resources.getColor(foregroundColors[i]);
+			Color color = new Color(foregroundColors[i]);
 			axes[i].getTick().setForeground(color);
 		}
 	}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/ChartPage.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/ChartPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -166,9 +166,9 @@ public class ChartPage extends AbstractPage {
 	@Override
 	public void apply() {
 
-		Color color = Resources.getColor(backgroundInPlotAreaButton.getColorValue());
+		Color color = new Color(backgroundInPlotAreaButton.getColorValue());
 		chart.getPlotArea().setBackground(color);
-		color = Resources.getColor(backgroundButton.getColorValue());
+		color = new Color(backgroundButton.getColorValue());
 		chart.setBackground(color);
 		chart.setOrientation(orientationButton.getSelection() ? SWT.VERTICAL : SWT.HORIZONTAL);
 		ITitle title = chart.getTitle();
@@ -178,7 +178,7 @@ public class ChartPage extends AbstractPage {
 		fontData.setHeight(fontSizeSpinner.getSelection());
 		Font font = Resources.getFont(fontData);
 		title.setFont(font);
-		color = Resources.getColor(titleColorButton.getColorValue());
+		color = new Color(titleColorButton.getColorValue());
 		title.setForeground(color);
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/GridPage.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/GridPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,7 +28,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.IAxis.Direction;
 import org.eclipse.swtchart.LineStyle;
-import org.eclipse.swtchart.Resources;
 import org.eclipse.swtchart.extensions.charts.InteractiveChart;
 
 /**
@@ -146,7 +145,7 @@ public class GridPage extends AbstractSelectorPage {
 
 		for(int i = 0; i < axes.length; i++) {
 			axes[i].getGrid().setStyle(styles[i]);
-			Color color = Resources.getColor(foregroundColors[i]);
+			Color color = new Color(foregroundColors[i]);
 			axes[i].getGrid().setForeground(color);
 		}
 	}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/LegendPage.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/LegendPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -145,9 +145,9 @@ public class LegendPage extends AbstractPage {
 	public void apply() {
 
 		legend.setVisible(showLegendButton.getSelection());
-		Color color = Resources.getColor(backgroundButton.getColorValue());
+		Color color = new Color(backgroundButton.getColorValue());
 		legend.setBackground(color);
-		color = Resources.getColor(foregroundButton.getColorValue());
+		color = new Color(foregroundButton.getColorValue());
 		legend.setForeground(color);
 		FontData fontData = legend.getFont().getFontData()[0];
 		Font font = Resources.getFont(fontData.getName(), fontSizeSpinner.getSelection(), fontData.getStyle());

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/SeriesLabelPage.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/SeriesLabelPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -159,7 +159,7 @@ public class SeriesLabelPage extends AbstractSelectorPage {
 
 		for(int i = 0; i < series.length; i++) {
 			series[i].getLabel().setVisible(visibleStates[i]);
-			Color color = ResourceSupport.getColor(colors[i]);
+			Color color = new Color(colors[i]);
 			series[i].getLabel().setForeground(color);
 			FontData fontData = series[i].getLabel().getFont().getFontData()[0];
 			fontData.setHeight(fontSizes[i]);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/SeriesPage.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/SeriesPage.java
@@ -35,7 +35,6 @@ import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
 import org.eclipse.swtchart.ISeries;
 import org.eclipse.swtchart.LineStyle;
 import org.eclipse.swtchart.extensions.charts.InteractiveChart;
-import org.eclipse.swtchart.extensions.core.ResourceSupport;
 
 /**
  * The series page on properties dialog.
@@ -392,15 +391,15 @@ public class SeriesPage extends AbstractSelectorPage {
 		for(int i = 0; i < series.length; i++) {
 			series[i].setVisible(visibleStates[i]);
 			if(series[i] instanceof ILineSeries<?> lineSeries) {
-				Color lineColor = ResourceSupport.getColor(lineColors[i]);
-				Color symbolColor = ResourceSupport.getColor(symbolColors[i]);
+				Color lineColor = new Color(lineColors[i]);
+				Color symbolColor = new Color(symbolColors[i]);
 				lineSeries.setLineColor(lineColor);
 				lineSeries.setSymbolColor(symbolColor);
 				lineSeries.setLineStyle(lineStyles[i]);
 				lineSeries.setSymbolType(symbolTypes[i]);
 				lineSeries.setSymbolSize(symbolSizes[i]);
 			} else if(series[i] instanceof IBarSeries<?> barSeries) {
-				Color barColor = ResourceSupport.getColor(barColors[i]);
+				Color barColor = new Color(barColors[i]);
 				barSeries.setBarColor(barColor);
 				barSeries.setBarPadding(paddings[i]);
 			}

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/Resources.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/Resources.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 Lablicate GmbH.
+ * Copyright (c) 2008, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.TextLayout;
 import org.eclipse.swt.widgets.Display;
 
@@ -37,7 +36,6 @@ public class Resources {
 	public static final int SMALL_FONT_SIZE = 9;
 	public static final String RGB_DELIMITER = ",";
 
-	private static final Map<RGB, Color> colorMap = new HashMap<>();
 	private static final Map<String, Font> fontMap = new HashMap<>();
 	private static final Map<String, TextLayout> textLayoutMap = new HashMap<>();
 
@@ -62,7 +60,7 @@ public class Resources {
 				int green = Integer.parseInt(values[1]);
 				int blue = Integer.parseInt(values[2]);
 
-				return getColor(new RGB(red, green, blue));
+				return new Color(red, green, blue);
 			}
 		}
 
@@ -84,38 +82,6 @@ public class Resources {
 		builder.append(color.getBlue());
 
 		return builder.toString();
-	}
-
-	/**
-	 * The color is mapped and disposed by this color support.
-	 * Hence, it doesn't need to be disposed manually.
-	 * 
-	 * @param rgb
-	 * @return color
-	 */
-	public static Color getColor(RGB rgb) {
-
-		Color color = colorMap.get(rgb);
-		if(color == null) {
-			color = new Color(rgb);
-			colorMap.put(rgb, color);
-		}
-		return color;
-	}
-
-	/**
-	 * The color is mapped and disposed by this color support.
-	 * Hence, it doesn't need to be disposed manually.
-	 * 
-	 * @param red
-	 * @param green
-	 * @param blue
-	 * @return color
-	 */
-	public static Color getColor(int red, int green, int blue) {
-
-		RGB rgb = new RGB(red, green, blue);
-		return getColor(rgb);
 	}
 
 	public static Font getFont(FontData fontData) {

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/compress/CompressCircularSeries.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/compress/CompressCircularSeries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,6 @@ import java.util.List;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swtchart.Resources;
 import org.eclipse.swtchart.model.Node;
 import org.eclipse.swtchart.model.NodeDataModel;
 
@@ -60,7 +59,7 @@ public class CompressCircularSeries extends Compress {
 			float brightness = Math.max(0, (i - 1) / ((float)maxTreeDepth));
 			for(int j = 0; j != length; j++) {
 				RGB rgb = new RGB(anglePerNode * j, 1, 1 - brightness);
-				Color color = Resources.getColor(rgb);
+				Color color = new Color(rgb);
 				nodes[i].get(j).setSliceColor(color);
 			}
 		}

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/compress/CompressPieSeries.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/compress/CompressPieSeries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swtchart.Resources;
 
 public class CompressPieSeries extends Compress {
 
@@ -95,7 +94,7 @@ public class CompressPieSeries extends Compress {
 		float anglePerColor = 360 / colour;
 		colors = new Color[colour];
 		for(int i = 0; i != colour; i++) {
-			colors[i] = Resources.getColor(new RGB(anglePerColor * i, 1, 1));
+			colors[i] = new Color(new RGB(anglePerColor * i, 1, 1));
 		}
 	}
 }

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/BarSeries.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/BarSeries.java
@@ -25,7 +25,6 @@ import org.eclipse.swtchart.Chart;
 import org.eclipse.swtchart.IAxis.Direction;
 import org.eclipse.swtchart.IBarSeries;
 import org.eclipse.swtchart.Range;
-import org.eclipse.swtchart.Resources;
 import org.eclipse.swtchart.internal.axis.Axis;
 import org.eclipse.swtchart.internal.compress.CompressBarSeries;
 import org.eclipse.swtchart.internal.compress.CompressScatterSeries;
@@ -398,7 +397,7 @@ public class BarSeries<T> extends Series<T> implements IBarSeries<T> {
 		red *= (red > 128) ? 0.8 : 1.2;
 		green *= (green > 128) ? 0.8 : 1.2;
 		blue *= (blue > 128) ? 0.8 : 1.2;
-		return Resources.getColor(red, green, blue);
+		return new Color(red, green, blue);
 	}
 
 	@Override


### PR DESCRIPTION
new Color(RGB) allocates no OS handle and holds no Device, so the static colorMap cached objects that nothing had to manage. It was never emptied either - the only cleanup path was a finalizer on a class that is never instantiated - and it gained an entry per distinct RGB, without a ceiling where the pie and circular series derive a fresh RGB per slice.

getColor(RGB) and getColor(int, int, int) are gone, callers construct the Color directly. That drops two public methods from an exported package and is not binary compatible.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])